### PR TITLE
Remove Gemini and Vertex auth validation

### DIFF
--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -13,31 +13,9 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     return null;
   }
 
-  if (authMethod === AuthType.USE_GEMINI) {
-    if (!process.env.GEMINI_API_KEY) {
-      return 'GEMINI_API_KEY environment variable not found. Add that to your .env and try again, no reload needed!';
-    }
-    return null;
-  }
-
   if (authMethod === AuthType.USE_DEEPSEEK) {
     if (!process.env.DEEPSEEK_API_KEY) {
       return 'DEEPSEEK_API_KEY environment variable not found. Add that to your .env and try again, no reload needed!';
-    }
-    return null;
-  }
-
-  if (authMethod === AuthType.USE_VERTEX_AI) {
-    const hasVertexProjectLocationConfig =
-      !!process.env.GOOGLE_CLOUD_PROJECT && !!process.env.GOOGLE_CLOUD_LOCATION;
-    const hasGoogleApiKey = !!process.env.GOOGLE_API_KEY;
-    if (!hasVertexProjectLocationConfig && !hasGoogleApiKey) {
-      return (
-        'Must specify GOOGLE_GENAI_USE_VERTEXAI=true and either:\n' +
-        '• GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables.\n' +
-        '• GOOGLE_API_KEY environment variable (if using express mode).\n' +
-        'Update your .env and try again, no reload needed!'
-      );
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- simplify auth validation in the CLI
- only check for `DEEPSEEK_API_KEY`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9a10952c832fb9eafe6c4bc00605