### PR TITLE
Rename gemini-cli to deepseek-cli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # By default, require reviews from the release approvers for all files.
-* @google-gemini/gemini-cli-askmode-approvers
+* @deepseek-ai/deepseek-cli-askmode-approvers
 
 # The following files don't need reviews from the release approvers.
 # These patterns override the rule above.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report! Please search [existing issues](https://github.com/google-gemini/gemini-cli/issues) to see if an issue already exists for the bug you encountered.
+        Thanks for taking the time to fill out this bug report! Please search [existing issues](https://github.com/deepseek-ai/deepseek-cli/issues) to see if an issue already exists for the bug you encountered.
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to suggest an enhancement! Please search [existing issues](https://github.com/google-gemini/gemini-cli/issues) to see if a similar feature has already been requested.
+        Thanks for taking the time to suggest an enhancement! Please search [existing issues](https://github.com/deepseek-ai/deepseek-cli/issues) to see if a similar feature has already been requested.
 
   - type: textarea
     id: feature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ This section guides contributors on how to build, modify, and understand the dev
 To clone the repository:
 
 ```bash
-git clone https://github.com/google-gemini/gemini-cli.git # Or your fork's URL
+git clone https://github.com/deepseek-ai/deepseek-cli.git # Or your fork's URL
 cd gemini-cli
 ```
 
@@ -207,7 +207,7 @@ npm run lint
 ### Coding Conventions
 
 - Please adhere to the coding style, patterns, and conventions used throughout the existing codebase.
-- Consult [GEMINI.md](https://github.com/google-gemini/gemini-cli/blob/main/GEMINI.md) (typically found in the project root) for specific instructions related to AI-assisted development, including conventions for React, comments, and Git usage.
+- Consult [GEMINI.md](https://github.com/deepseek-ai/deepseek-cli/blob/main/GEMINI.md) (typically found in the project root) for specific instructions related to AI-assisted development, including conventions for React, comments, and Git usage.
 - **Imports:** Pay special attention to import paths. The project uses `eslint-rules/no-relative-cross-package-imports.js` to enforce restrictions on relative imports between packages.
 
 ### Project Structure

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-# Makefile for gemini-cli
+# Makefile for deepseek-cli
 
 .PHONY: help install build build-sandbox build-all test lint format preflight clean start debug release run-npx create-alias
 
 help:
-	@echo "Makefile for gemini-cli"
+	@echo "Makefile for deepseek-cli"
 	@echo ""
 	@echo "Usage:"
 	@echo "  make install          - Install npm dependencies"
@@ -58,7 +58,7 @@ release:
 	npm run publish:release
 
 run-npx:
-	npx https://github.com/google-gemini/gemini-cli
+	npx https://github.com/deepseek-ai/deepseek-cli
 
 create-alias:
 	scripts/create_alias.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [中文版](README.zh.md)
 
-[![Gemini CLI CI](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/google-gemini/gemini-cli/actions/workflows/ci.yml)
+[![Gemini CLI CI](https://github.com/deepseek-ai/deepseek-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/deepseek-ai/deepseek-cli/actions/workflows/ci.yml)
 
 ![Gemini CLI Screenshot](./docs/assets/gemini-screenshot.png)
 
@@ -25,7 +25,7 @@ With the Gemini CLI you can:
 2. **Run the CLI:** Execute the following command in your terminal:
 
    ```bash
-   npx https://github.com/google-gemini/gemini-cli
+   npx https://github.com/deepseek-ai/deepseek-cli
    ```
 
    Or install it with:
@@ -68,7 +68,7 @@ gemini
 Or work with an existing project:
 
 ```sh
-git clone https://github.com/google-gemini/gemini-cli
+git clone https://github.com/deepseek-ai/deepseek-cli
 cd gemini-cli
 gemini
 > Give me a summary of all of the changes that went in yesterday

--- a/README.zh.md
+++ b/README.zh.md
@@ -18,7 +18,7 @@ Gemini CLI 是一个命令行 AI 工作流工具，能够链接您的工具，�
 2. **运行 CLI：** 在终端中执行：
 
    ```bash
-   npx https://github.com/google-gemini/gemini-cli
+   npx https://github.com/deepseek-ai/deepseek-cli
    ```
 
    或使用以下命令安装：
@@ -61,7 +61,7 @@ gemini
 或与现有项目配合：
 
 ```sh
-git clone https://github.com/google-gemini/gemini-cli
+git clone https://github.com/deepseek-ai/deepseek-cli
 cd gemini-cli
 gemini
 > Give me a summary of all of the changes that went in yesterday

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -42,7 +42,7 @@ In addition to a project settings file, a project's `.gemini` directory can cont
 - **`bugCommand`** (object):
 
   - **Description:** Overrides the default URL for the `/bug` command.
-  - **Default:** `"urlTemplate": "https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title={title}&info={info}"`
+  - **Default:** `"urlTemplate": "https://github.com/deepseek-ai/deepseek-cli/issues/new?template=bug_report.yml&title={title}&info={info}"`
   - **Properties:**
     - **`urlTemplate`** (string): A URL that can contain `{title}` and `{info}` placeholders.
   - **Example:**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -77,7 +77,7 @@ You can run the most recently committed version of Gemini CLI directly from the 
 
 ```bash
 # Execute the CLI directly from the main branch on GitHub
-npx https://github.com/google-gemini/gemini-cli
+npx https://github.com/deepseek-ai/deepseek-cli
 ```
 
 ## Deployment architecture

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@google/gemini-cli",
+  "name": "@google/deepseek-cli",
   "version": "0.1.5",
   "engines": {
     "node": ">=18.0.0"
@@ -8,9 +8,9 @@
   "workspaces": [
     "packages/*"
   ],
-  "repository": "google-gemini/gemini-cli",
+  "repository": "deepseek-ai/deepseek-cli",
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.4"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/deepseek-cli/sandbox:0.1.4"
   },
   "scripts": {
     "generate": "node scripts/generate-git-commit-info.js",
@@ -85,6 +85,6 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@google/gemini-cli": "^0.1.1"
+    "@google/deepseek-cli": "^0.1.1"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@google/gemini-cli",
   "version": "0.1.5",
   "description": "Gemini CLI",
-  "repository": "google-gemini/gemini-cli",
+  "repository": "deepseek-ai/deepseek-cli",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -99,7 +99,7 @@ export function AuthDialog({
       <Box marginTop={1}>
         <Text color={Colors.AccentBlue}>
           {
-            'https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md'
+            'https://github.com/deepseek-ai/deepseek-cli/blob/main/docs/tos-privacy.md'
           }
         </Text>
       </Box>

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -417,7 +417,7 @@ describe('useSlashCommandProcessor', () => {
 *   **Memory Usage:** ${memoryUsage}
 `;
       let url =
-        'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml';
+        'https://github.com/deepseek-ai/deepseek-cli/issues/new?template=bug_report.yml';
       if (description) {
         url += `&title=${encodeURIComponent(description)}`;
       }

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -639,7 +639,7 @@ export const useSlashCommandProcessor = (
 `;
 
           let bugReportUrl =
-            'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title={title}&info={info}';
+            'https://github.com/deepseek-ai/deepseek-cli/issues/new?template=bug_report.yml&title={title}&info={info}';
           const bugCommand = config?.getBugCommand();
           if (bugCommand?.urlTemplate) {
             bugReportUrl = bugCommand.urlTemplate;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@google/gemini-cli-core",
   "version": "0.1.5",
   "description": "Gemini CLI Server",
-  "repository": "google-gemini/gemini-cli",
+  "repository": "deepseek-ai/deepseek-cli",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -68,7 +68,7 @@ const customDockerfile = argv.f;
 
 if (!baseImage?.length) {
   console.warn(
-    'No default image tag specified in gemini-cli/packages/cli/package.json',
+    'No default image tag specified in deepseek-cli/packages/cli/package.json',
   );
 }
 
@@ -77,23 +77,23 @@ if (!argv.s) {
   execSync('npm run build --workspaces', { stdio: 'inherit' });
 }
 
-console.log('packing @google/gemini-cli ...');
+console.log('packing @google/deepseek-cli ...');
 const cliPackageDir = join('packages', 'cli');
-rmSync(join(cliPackageDir, 'dist', 'google-gemini-cli-*.tgz'), { force: true });
+rmSync(join(cliPackageDir, 'dist', 'google-deepseek-cli-*.tgz'), { force: true });
 execSync(
-  `npm pack -w @google/gemini-cli --pack-destination ./packages/cli/dist`,
+  `npm pack -w @google/deepseek-cli --pack-destination ./packages/cli/dist`,
   {
     stdio: 'ignore',
   },
 );
 
-console.log('packing @google/gemini-cli-core ...');
+console.log('packing @google/deepseek-cli-core ...');
 const corePackageDir = join('packages', 'core');
-rmSync(join(corePackageDir, 'dist', 'google-gemini-cli-core-*.tgz'), {
+rmSync(join(corePackageDir, 'dist', 'google-deepseek-cli-core-*.tgz'), {
   force: true,
 });
 execSync(
-  `npm pack -w @google/gemini-cli-core --pack-destination ./packages/core/dist`,
+  `npm pack -w @google/deepseek-cli-core --pack-destination ./packages/core/dist`,
   { stdio: 'ignore' },
 );
 
@@ -102,11 +102,11 @@ const packageVersion = JSON.parse(
 ).version;
 
 chmodSync(
-  join(cliPackageDir, 'dist', `google-gemini-cli-${packageVersion}.tgz`),
+  join(cliPackageDir, 'dist', `google-deepseek-cli-${packageVersion}.tgz`),
   0o755,
 );
 chmodSync(
-  join(corePackageDir, 'dist', `google-gemini-cli-core-${packageVersion}.tgz`),
+  join(corePackageDir, 'dist', `google-deepseek-cli-core-${packageVersion}.tgz`),
   0o755,
 );
 

--- a/scripts/check-build-status.js
+++ b/scripts/check-build-status.js
@@ -17,7 +17,7 @@ const filesToWatch = [
   path.join(cliPackageDir, 'tsconfig.json'),
 ]; // Specific files within the CLI package
 const buildDir = path.join(cliPackageDir, 'dist'); // Build output directory within the CLI package
-const warningsFilePath = path.join(os.tmpdir(), 'gemini-cli-warnings.txt'); // Temp file for warnings
+const warningsFilePath = path.join(os.tmpdir(), 'deepseek-cli-warnings.txt'); // Temp file for warnings
 // ---------------------
 
 function getMtime(filePath) {

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -19,9 +19,9 @@ if (!fs.existsSync(packageJsonPath)) {
   errors.push(`Error: package.json not found in ${process.cwd()}`);
 } else {
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-  if (packageJson.repository !== 'google-gemini/gemini-cli') {
+  if (packageJson.repository !== 'deepseek-ai/deepseek-cli') {
     errors.push(
-      `Error: The "repository" field in ${packageJsonPath} must be "google-gemini/gemini-cli".`,
+      `Error: The "repository" field in ${packageJsonPath} must be "deepseek-ai/deepseek-cli".`,
     );
   }
 }

--- a/scripts/sandbox.js
+++ b/scripts/sandbox.js
@@ -41,7 +41,7 @@ if (argv.i && !process.stdin.isTTY) {
   process.exit(1);
 }
 
-const image = 'gemini-cli-sandbox';
+const image = 'deepseek-cli-sandbox';
 const sandboxCommand = execSync('node scripts/sandbox_command.js')
   .toString()
   .trim();
@@ -69,7 +69,7 @@ if (firstArg) {
 if (!sandboxName) {
   if (sandboxes.length === 0) {
     console.error(
-      'No sandboxes found. Are you running gemini-cli with sandboxing enabled?',
+      'No sandboxes found. Are you running deepseek-cli with sandboxing enabled?',
     );
     process.exit(1);
   }

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -41,11 +41,11 @@ export const WORKSPACE_SETTINGS_FILE = path.join(
 export function getJson(url) {
   const tmpFile = path.join(
     os.tmpdir(),
-    `gemini-cli-releases-${Date.now()}.json`,
+    `deepseek-cli-releases-${Date.now()}.json`,
   );
   try {
     execSync(
-      `curl -sL -H "User-Agent: gemini-cli-dev-script" -o "${tmpFile}" "${url}"`,
+      `curl -sL -H "User-Agent: deepseek-cli-dev-script" -o "${tmpFile}" "${url}"`,
       { stdio: 'pipe' },
     );
     const content = fs.readFileSync(tmpFile, 'utf-8');
@@ -217,7 +217,7 @@ export async function ensureBinary(
 
   const downloadUrl = asset.browser_download_url;
   const tmpDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'gemini-cli-telemetry-'),
+    path.join(os.tmpdir(), 'deepseek-cli-telemetry-'),
   );
   const archivePath = path.join(tmpDir, asset.name);
 


### PR DESCRIPTION
## Summary
- rename project references from `gemini-cli` to `deepseek-cli`
- update repository links and CI badge
- keep scripts consistent with new name

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9a12b650832fa27067baabb3ec0e